### PR TITLE
fix issue "Selected Language did not cashed"

### DIFF
--- a/lib/Core/Shared/cubit/locale/locale_manger_cubit.dart
+++ b/lib/Core/Shared/cubit/locale/locale_manger_cubit.dart
@@ -5,18 +5,16 @@ import 'package:tiktok_flutter_clone/Core/Shared/class/local_cashe_helper.dart';
 part 'locale_manger_state.dart';
 
 class LocaleMangerCubit extends Cubit<LocaleMangerState> {
-  LocaleMangerCubit() : super(LocaleSuccesState(const Locale("ar")));
+  LocaleMangerCubit() : super(LocaleMangerState(const Locale("ar")));
 
   Future<void> getCacheLocale() async {
-    emit(LocaleLoadingState());
     final cacheHelper = await CacheHelper().getLocale();
 
-    emit(LocaleSuccesState(Locale(cacheHelper)));
+    emit(LocaleMangerState(Locale(cacheHelper)));
   }
 
   Future<void> setCachLocal(String val) async {
-    emit(LocaleLoadingState());
     await CacheHelper().cacheLocale(val);
-    emit(LocaleSuccesState(Locale(val)));
+    emit(LocaleMangerState(Locale(val)));
   }
 }

--- a/lib/Core/Shared/cubit/locale/locale_manger_state.dart
+++ b/lib/Core/Shared/cubit/locale/locale_manger_state.dart
@@ -1,13 +1,7 @@
 part of 'locale_manger_cubit.dart';
 
-class LocaleMangerState {}
-
-final class LocaleMangerInitialState extends LocaleMangerState {}
-
-final class LocaleLoadingState extends LocaleMangerState {}
-
-final class LocaleSuccesState extends LocaleMangerState {
+class LocaleMangerState {
   final Locale locale;
 
-  LocaleSuccesState(this.locale);
+  LocaleMangerState(this.locale);
 }

--- a/lib/Features/home/view/home_view.dart
+++ b/lib/Features/home/view/home_view.dart
@@ -21,7 +21,7 @@ class HomeView extends StatelessWidget {
                 onPressed: () {
                   context.pushNamed(Routes.settings);
                 },
-                child: const Text("go to settings"))
+                child: const Text("go to settings +++"))
           ],
         ),
       ),

--- a/lib/Features/settings/widgets/custom_locale_drop_down.dart
+++ b/lib/Features/settings/widgets/custom_locale_drop_down.dart
@@ -19,7 +19,7 @@ class CustomLocaleDropDown extends StatelessWidget {
         trailing: BlocBuilder<LocaleMangerCubit, LocaleMangerState>(
           builder: (context, state) {
             return DropdownButton(
-                value: (state is LocaleSuccesState)
+                value: (state is LocaleMangerState)
                     ? state.locale.languageCode
                     : null,
                 items: [

--- a/lib/main_app.dart
+++ b/lib/main_app.dart
@@ -27,7 +27,7 @@ class MainApp extends StatelessWidget {
             localizationsDelegates: localizationsDelegates,
             supportedLocales: S.delegate.supportedLocales,
 
-            locale: (state is LocaleSuccesState)
+            locale: (state is LocaleMangerState)
                 ? state.locale
                 : const Locale("en"),
             //deview preview

--- a/lib/main_app.dart
+++ b/lib/main_app.dart
@@ -27,9 +27,7 @@ class MainApp extends StatelessWidget {
             localizationsDelegates: localizationsDelegates,
             supportedLocales: S.delegate.supportedLocales,
 
-            locale: (state is LocaleMangerState)
-                ? state.locale
-                : const Locale("en"),
+            locale: state.locale,
             //deview preview
             builder: DevicePreview.appBuilder,
           ),


### PR DESCRIPTION
- refactor LocaleMangerState to use one single state.